### PR TITLE
Use tito for input type parsing

### DIFF
--- a/lib/tables.js
+++ b/lib/tables.js
@@ -103,9 +103,12 @@ function Tables(options) {
   if (options.input && !fs.existsSync(options.input)) {
     throw new Error("options.input file given but does not exist.");
   }
+
+  /*
   if (["csv", "json", "custom"].indexOf(options.inputType) === -1) {
     throw new Error("options.inputType not supported.");
   }
+  */
 
   // Check for stdin
   if (!options.input) {
@@ -426,17 +429,17 @@ Tables.prototype.guessModel = function() {
   }
 };
 
-// Guess table name from input`
+// Guess table name from input
 Tables.prototype.guessTableName = function(input) {
-  var parts;
+  var filename;
 
   // We may not have an input file name to go from
   if (!input) {
     return "tables_import";
   }
 
-  parts = input.split("/");
-  return utils.toSQLName(parts[parts.length - 1].replace(".csv", "").replace(".json", ""));
+  filename = input.split("/").pop();
+  return utils.toSQLName(filename.replace(/.[a-z]+$/, ""));
 };
 
 // Get info about input file

--- a/lib/tables.js
+++ b/lib/tables.js
@@ -16,6 +16,7 @@ var Sequelize = require("sequelize");
 var queue = require("d3-queue").queue;
 var unpipe = require("unpipe");
 var merge = require("merge2");
+var tito = require("tito");
 
 var output = require("./output.js");
 var utils = require("./utils.js");
@@ -483,34 +484,19 @@ Tables.prototype.bar = function() {
 
 // Make input parser
 Tables.prototype.inputParser = function() {
-  var JSONStream;
-  var csvParser;
+  var type = this.options.inputType;
+  var options = this.options.inputOptions;
 
-  // JSON parser
-  // https://github.com/dominictarr/JSONStream
-  if (this.options.inputType === "json") {
-    this.output.item("JSON pipe");
-    JSONStream = require("JSONStream");
-    return JSONStream.parse(this.options.inputOptions);
-  }
-  // CSV parser
-  // http://csv.adaltas.com/parse/
-  else if (this.options.inputType === "csv") {
-    this.output.item("CSV pipe");
-    csvParser = require("fast-csv");
-
-    // For some reason the delimiter character gets escaped
-    this.options.inputOptions.delimiter = this.options.inputOptions.delimiter ?
-      this.options.inputOptions.delimiter.replace(/\\/g, "") :
-      this.options.inputOptions.delimiter;
-
-    return csvParser(this.options.inputOptions);
-  }
-  // Custom pipe
-  else if (this.options.inputType === "custom" && this.options.pipe) {
+  // if the type is explicitly "custom", or if the pipe option is set
+  if (type === "custom") {
     this.output.item("Custom pipe");
     return this.options.pipe;
   }
+
+  return tito.formats.createReadStream(
+    this.options.inputType,
+    this.options.inputOptions
+  );
 };
 
 // Make sequelize connection

--- a/lib/tables.js
+++ b/lib/tables.js
@@ -492,16 +492,17 @@ Tables.prototype.inputParser = function() {
   var type = this.options.inputType;
   var options = this.options.inputOptions;
 
-  // if the type is explicitly "custom", or if the pipe option is set
+  // if the type is explicitly "custom"
   if (type === "custom") {
     this.output.item("Custom pipe");
     return this.options.pipe;
+  } else if (type === "json" && typeof options === "string") {
+    // normalize a JSONPath expression string to an options object
+    // for streaming JSON
+    options = {path: options};
   }
 
-  return tito.formats.createReadStream(
-    this.options.inputType,
-    this.options.inputOptions
-  );
+  return tito.formats.createReadStream(type, options);
 };
 
 // Make sequelize connection

--- a/lib/tables.js
+++ b/lib/tables.js
@@ -63,15 +63,17 @@ function Tables(options) {
     options.inputType = "custom";
     options.inputOptions = options.inputOptions || {};
   }
+
   if (!options.inputType && options.input) {
-    if (options.input.indexOf(".csv") !== -1) {
-      options.inputType = "csv";
-    }
-    else if (options.input.indexOf(".json") !== -1) {
-      options.inputType = "json";
+    // try to guess the input type from the filename
+    var match = options.input.match(/\.([a-z]+)$/);
+    if (match) {
+      options.inputType = match[1];
+      this.output.item("Guessed input type: '" + options.inputType + "'");
     }
   }
-  else if (!options.inputType) {
+
+  if (!options.inputType) {
     options.inputType = "csv";
   }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "node": ">=0.10.3 <=4.4.0"
   },
   "dependencies": {
-    "JSONStream": "^1.1.1",
     "chalk": "^1.1.1",
     "cli-spinner": "^0.2.4",
     "commander": "^2.9.0",
@@ -36,7 +35,6 @@
     "d3-queue": "^2.0.3",
     "dotenv": "^2.0.0",
     "event-stream": "^3.3.2",
-    "fast-csv": "^1.0.0",
     "lodash": "^4.6.1",
     "merge2": "^1.0.1",
     "moment-timezone": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "progress": "^1.1.8",
     "sequelize": "^3.19.3",
     "sqlite3": "^3.1.1",
+    "tito": "^0.4.0",
     "unpipe": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR brings in [tito](/shawnbot/tito) for input parsing, which gives you more format options (such as TSV, newline-delimited JSON, and even HTML tables) out of the box, and saves you from having to juggle different types and manage their respective dependencies.

Tito also uses fast-csv and JSONStream under the hood, but there appears to be a difference in the how the parser options are handled, since tito expects an object with a `path` property rather than a path expression as a string. So if the `inputType` is `json` _and_ `inputOptions` is a string, then I normalize it to the form `{path: inputOptions}`.