### PR TITLE
Don't warn for Node v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/datanews/tables#readme",
   "engines": {
-    "node": ">=0.10.3 <=4.4.0"
+    "node": ">=0.10.3"
   },
   "dependencies": {
     "chalk": "^1.1.1",


### PR DESCRIPTION
I've tested this with the sqlite3 v3.1.2 on Node v5.10.0, and it works! There shouldn't be any need to warn users about it.